### PR TITLE
优化评论缩进显示效果

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -15498,7 +15498,7 @@ html:not([dir='rtl']) .noUi-horizontal .noUi-handle {
     margin-bottom: 40px;
 }
 
-.comment-children ol {
+.comment-child-indent {
     padding-left: 40px;
 }
 
@@ -15526,9 +15526,8 @@ html:not([dir='rtl']) .noUi-horizontal .noUi-handle {
         width: 40px !important;
         height: 40px !important;
     }
-    .comment-children ol {
-        padding-left: 15px !important;
-        border-left: 1px #cfcfcf solid;
+    .comment-child-indent {
+        padding-left: 20px;
     }
 }
 

--- a/comments.php
+++ b/comments.php
@@ -1,9 +1,17 @@
 
 <?php function threadedComments($comments, $options) {
 		$commentLevelClass = $comments->_levels > 0 ? ' comment-child' : ' comment-parent';
+
+		$indent = true;
+		$commentLine = GetCommentLineInDb($comments->coid);
+		/* 有上上层评论且上上层评论和本层评论是同一个人 */
+		if(count($commentLine)==3 and ($commentLine[2]['author'] == $comments->author))
+			$indent = false;
+		if(count($commentLine)==1) /* 如果是最顶层的回复同样不需要缩进 */
+			$indent = false;
 ?>
  
-<li id="li-<?php $comments->theId(); ?>">
+<li id="li-<?php $comments->theId(); ?>" class="<?php echo($indent? 'comment-child-indent':''); ?>">
 	<div id="<?php $comments->theId(); ?>">
 		<div  class="comment-item">
 			<div class="<?php 
@@ -17,7 +25,7 @@
 			</div>
 			<div class="comment-body">
 				<div class="comment-head">
-					<h5><?php if ($comments->url) { ?><a target="_blank" rel="external nofollow" href="<?php echo $comments->url; ?>"><?php echo $comments->author; ?></a><?php } else { ?><?php echo $comments->author; ?><?php } ?> · <small><?php $comments->date('Y-m-d H:i'); ?></small><?php
+					<h5><?php if ($comments->url) { ?><a target="_blank" rel="external nofollow" href="<?php echo $comments->url; ?>"><?php echo $comments->author; ?></a><?php } else { ?><?php echo $comments->author; ?><?php } ?><?php echo(count($commentLine) > 1?' <small>回复</small> ' . $commentLine[1]['author']:''); ?> · <small><?php $comments->date('Y-m-d H:i'); ?></small><?php
 					if ($comments->status == 'waiting') {
 						?><span class="badge badge-pill badge-default text-white">评论审核ing...</span><?php
 					}

--- a/functions.php
+++ b/functions.php
@@ -392,6 +392,18 @@ function getCatalog() {
 	echo $index;
 }
 
+function GetCommentLineInDb($coid, $depth=3) { // 3 for getting this comment, the parent and the grandparent by default
+	$db = Typecho_Db::get();
+	$commentLine = [];
+	while((count($commentLine) < $depth) and (isset($coid) and 0 != $coid)) {
+		$row = $db->fetchRow($db->select()->from('table.comments')->where('coid = ? ', $coid));
+		if(empty($row)) break;
+		array_push($commentLine, $row);
+		$coid = $row['parent'];
+	}
+	return $commentLine;
+}
+
 function themeInit($archive) {
 	if ($archive->is('single')) {
 		$archive->content = createCatalog($archive->content);


### PR DESCRIPTION
默认的评论效果是一层嵌一层，回复次数多了以后会变成这样
```
A: balabal
    B: balabal
        A: balabal
            C: balabal
```
优化后的效果是这样

如果是两个人不断地互相回复会对齐评论内容，如果他人插入对话则会在下方从新缩进。(哎呀好绕啊，看下面的图片应该就能明白了)

此效果依然会受到TYPECHO的最大回复层数的限制

![aaaaaa](https://res.innc11.cn/pictures/bubble/2020-08-22-131746.png)
